### PR TITLE
Enhancements & Bug Fixes

### DIFF
--- a/Backend/ecosystem.config.js
+++ b/Backend/ecosystem.config.js
@@ -10,7 +10,10 @@ function getAppName() {
 
 module.exports = {
   apps : [{
-    name   : getAppName(),
-    script : "./dist/index.js"
+      name   : getAppName(),
+      script : "./dist/index.js",
+      args: [
+          "--color"
+      ]
   }]
 }

--- a/Backend/src/api/accounts/index.ts
+++ b/Backend/src/api/accounts/index.ts
@@ -13,6 +13,7 @@ import {
 
 import {accountExistsMiddle} from "../../middlewares";
 import {logToConsole} from "../../utils/logger";
+import {canUserEditAccount} from "../../middlewares/account-exists";
 
 const app = express.Router();
 
@@ -33,16 +34,16 @@ app.post("/change-password", changeUserPasswordController);
 app.get("/:nif/forces", accountExistsMiddle, getAccountForcesController);
 
 // Endpoint to reset the password of another account
-app.post("/:nif/reset-password", accountExistsMiddle, resetPasswordController);
+app.post("/:nif/reset-password", accountExistsMiddle, canUserEditAccount, resetPasswordController);
 
 // Endpoint to get a user's accounts information
-app.get("/:nif", accountExistsMiddle, getUserAccountDetailsController);
+app.get("/:nif", accountExistsMiddle, canUserEditAccount, getUserAccountDetailsController);
 
 // Endpoint to create an account
 app.post("/:nif", createAccountController);
 
-// Endpoint to edit an account's permissions / suspended statuses
-app.patch("/:nif", accountExistsMiddle, changeAccountDetailsController);
+// Endpoint to edit an account's permissions, suspended statuses and authentication methods
+app.patch("/:nif", accountExistsMiddle, canUserEditAccount, changeAccountDetailsController);
 
 // Endpoint to delete an account
 // ! This endpoint will rarely be used since there's no big reason to need to delete an account

--- a/Backend/src/api/patrols/repository/index.ts
+++ b/Backend/src/api/patrols/repository/index.ts
@@ -110,7 +110,7 @@ export async function isOfficerInPatrol(force: string, officerNif: number, start
                                                     )
                                                  OR 
                                                     (
-                                                        (? > start AND end IS NUll)    
+                                                        (? > start AND end IS NULL)    
                                                     )
                                                  )`, [`%${officerNif}%`, start, end, start, end, start, end, end]);
     }

--- a/Backend/src/api/patrols/repository/index.ts
+++ b/Backend/src/api/patrols/repository/index.ts
@@ -110,7 +110,7 @@ export async function isOfficerInPatrol(force: string, officerNif: number, start
                                                     )
                                                  OR 
                                                     (
-                                                        (? > start)    
+                                                        (? > start AND end IS NUll)    
                                                     )
                                                  )`, [`%${officerNif}%`, start, end, start, end, start, end, end]);
     }

--- a/Backend/src/middlewares/account-exists.ts
+++ b/Backend/src/middlewares/account-exists.ts
@@ -3,6 +3,7 @@ import express from "express";
 import {getAccountDetails} from "../api/accounts/repository";
 import {AccountInfoAPIResponse} from "../types/response-types";
 import {FORCE_HEADER} from "../utils/constants";
+import {getOfficerData} from "../api/officers/repository";
 
 async function accountExistsMiddle(req: express.Request, res: AccountInfoAPIResponse, next: express.NextFunction) {
     const {nif} = req.params;
@@ -20,5 +21,30 @@ async function accountExistsMiddle(req: express.Request, res: AccountInfoAPIResp
 
     next();
 }
+
+export async function canUserEditAccount(req: express.Request, res: AccountInfoAPIResponse, next: express.NextFunction) {
+    // For an user to be able to edit an account, the following conditions must be true
+    // - The user has the "accounts" intent (this is handled by the routes file)
+    // - The user has higher patent than the target account
+
+    // If the requesting officer has the same NIF as the target account, allow it
+    if (res.locals.loggedOfficer.nif === res.locals.targetAccount.nif) {
+        next();
+        return;
+    }
+
+    // Get officer data of the target account
+    const targetData = await getOfficerData(res.locals.targetAccount.nif, req.header(FORCE_HEADER)!, false, false);
+
+    if (res.locals.loggedOfficer.patent <= targetData!.patent) {
+        res.status(403).json({
+            message: "Não tem permissões para editar esta conta"
+        });
+        return;
+    }
+
+    next();
+}
+
 
 export default accountExistsMiddle;

--- a/Backend/src/middlewares/officer-exists.ts
+++ b/Backend/src/middlewares/officer-exists.ts
@@ -17,17 +17,6 @@ async function officerExistsMiddle(req: Request, res: OfficerInfoAPIResponse, ne
         return;
     }
 
-    // If it's not, check if it's a former officer
-    officerResult = await getOfficerData(Number(req.params.nif), req.header(FORCE_HEADER)!, true);
-
-    if (officerResult !== null) {
-        res.locals.targetOfficer = officerResult;
-        res.locals.targetOfficer.isFormer = true;
-        res.locals.targetOfficer.force = req.header(FORCE_HEADER)!;
-        next();
-        return;
-    }
-
     // If this is the endpoint to fech an officer's data and the query parameter patrol is present, go through all forces the user can patrol with and check if the officer is in any of them
     if (res.locals.routeDetails.notes === "get_officer" && isQueryParamPresent("patrol", res.locals.queryParams) && res.locals.queryParams.patrol === "true") {
         for (const force of getForcePatrolForces(req.header(FORCE_HEADER)!)) {
@@ -50,6 +39,17 @@ async function officerExistsMiddle(req: Request, res: OfficerInfoAPIResponse, ne
                 return;
             }
         }
+    }
+
+    // If it's not, check if it's a former officer
+    officerResult = await getOfficerData(Number(req.params.nif), req.header(FORCE_HEADER)!, true);
+
+    if (officerResult !== null) {
+        res.locals.targetOfficer = officerResult;
+        res.locals.targetOfficer.isFormer = true;
+        res.locals.targetOfficer.force = req.header(FORCE_HEADER)!;
+        next();
+        return;
     }
 
     // If the officer doesn't exist, return a 404 status code, if the request is not to add a new officer

--- a/Backend/src/middlewares/patrol-exists.ts
+++ b/Backend/src/middlewares/patrol-exists.ts
@@ -30,10 +30,7 @@ async function patrolExistsMiddle(req: express.Request, res: PatrolInfoAPIRespon
     } else {
         // Now, check if the officer is appart of the patrol
         if (isOfficerPartOfPatrol) {
-            // Check if the patrol has ended for more than 30 minutes. If so, set the patrol as not editable
-            patrol.editable = !(patrol.end !== null && Date.now() - patrol.end.getTime() > (30 * 60 * 1000));
-        } else { // If not, set the patrol as not editable
-            patrol.editable = false;
+            patrol.editable = true;
         }
     }
 

--- a/Backend/src/utils/logger.ts
+++ b/Backend/src/utils/logger.ts
@@ -158,7 +158,7 @@ export async function logRequestToFile(res: ExpressResponse | APIResponse) {
     // Add the headers of the request to the log
     builder += "Headers:\n";
     for (const [key, value] of Object.entries(res.req.headers)) {
-        if (key !== "x-portalseguranca-force") continue; // Skip every header except the force header
+        if (key === "x-portalseguranca-force") continue; // Log every header except the force header
         builder += `- ${key}: ${value}\n`;
     }
 

--- a/Backend/src/utils/logger.ts
+++ b/Backend/src/utils/logger.ts
@@ -158,7 +158,7 @@ export async function logRequestToFile(res: ExpressResponse | APIResponse) {
     // Add the headers of the request to the log
     builder += "Headers:\n";
     for (const [key, value] of Object.entries(res.req.headers)) {
-        if (key === "x-portalseguranca-force") continue; // Log every header except the force header
+        if (key === FORCE_HEADER) continue; // Log every header except the force header
         builder += `- ${key}: ${value}\n`;
     }
 

--- a/Frontend/src/components/PatrolPicker/PatrolCard/index.tsx
+++ b/Frontend/src/components/PatrolPicker/PatrolCard/index.tsx
@@ -23,6 +23,7 @@ function PatrolCard({patrolInfo, callback}: PatrolCardProps) {
     const [loading, setLoading] = useState<boolean>(true);
     const [officers, setOfficers] = useState<(MinifiedOfficerData & {force: string})[] >([]);
     const [addEtc, setAddEtc] = useState<boolean>(false);
+    const [patrolDuration, setPatrolDuration] = useState<number>(0);
 
     // Getting the patrol force from the id
     const patrolForce = patrolInfo.id.match(/([a-z]+)(\d+)$/)![1];
@@ -78,6 +79,20 @@ function PatrolCard({patrolInfo, callback}: PatrolCardProps) {
         void exec();
     }, [patrolInfo.id]);
 
+    // Loop to keep updating the duration of ongoing patrols
+    useEffect(() => {
+        if (patrolInfo.end !== null) return;
+
+        const loop = setInterval(() => {
+           setPatrolDuration(moment().diff(moment.unix(patrolInfo.start)));
+        }, 500);
+
+        return () => {
+            setPatrolDuration(0);
+            clearInterval(loop);
+        }
+    }, [patrolInfo.start]);
+
     return (
         <InformationCard
             statusColor={patrolInfo.canceled ? "gray": (patrolInfo.end ? "red" : "lightgreen")}
@@ -90,7 +105,7 @@ function PatrolCard({patrolInfo, callback}: PatrolCardProps) {
                     </DefaultTypography>
 
                     <DefaultTypography color={"gray"}>{getObjectFromId(patrolInfo.type, getForceData(patrolForce).patrol_types)?.name} {patrolInfo.unit ? ` - ${getObjectFromId(patrolInfo.unit, getForceData(patrolForce).special_units)?.name}`: ""}</DefaultTypography>
-                    <DefaultTypography color={"gray"}>Duração: {patrolInfo.end ? moment.duration(moment.unix(patrolInfo.end).diff(moment.unix(patrolInfo.start))).format("hh[h]mm", {trim: false}): "N/A"}</DefaultTypography>
+                    <DefaultTypography color={"gray"}>Duração: {patrolInfo.end ? moment.duration(moment.unix(patrolInfo.end).diff(moment.unix(patrolInfo.start))).format("hh[h]mm", {trim: false}): moment.duration(patrolDuration).format("hh:mm:ss", {trim: false})}</DefaultTypography>
                 </div>
                 <div className={style.patrolCardMiddle}>
                     <Gate show={loading}>

--- a/Frontend/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/Frontend/src/components/PrivateRoute/PrivateRoute.tsx
@@ -154,7 +154,7 @@ function PrivateRoute({element, handleForceChange, isLoginPage = false}: Private
 
     // Add the Socket Event listener for the logged user's data
     useWebSocketEvent<OfficerSocket>(SOCKET_EVENT.OFFICERS, useCallback(data => {
-        if (data.nif === loggedUser.info.personal.nif) {
+        if (data.nif === loggedUser.info.personal.nif || data.nif === 0) { // If nif is 0, all users were affected
             void updateValues(false);
         }
     }, [socket?.id, loggedUser.info.personal.nif]), socket);

--- a/Frontend/src/pages/Activity/index.tsx
+++ b/Frontend/src/pages/Activity/index.tsx
@@ -339,9 +339,24 @@ function Activity() {
 
         const execute = async () => {
             // Before doing anything, check if the currentOfficer state is fully built
+            let officer;
             if (currentOfficer.name === "") {
                 // Since it's not fully built, we must fetch the officer's data from the nif
-                const officer = await getOfficerFromNif(currentOfficer.nif);
+                try {
+                    officer = await getOfficerFromNif(currentOfficer.nif, signal);
+                } catch (e) { // If something went wrong, we will set the officer to the logged user, forcing a re-render
+                    if (signal.aborted) throw e; // If the error was due to the request being aborted, rethrow it
+
+                    setCurrentOfficer({
+                        name: loggedUser.info.personal.name,
+                        patent: loggedUser.info.professional.patent.id,
+                        callsign: loggedUser.info.professional.callsign,
+                        status: loggedUser.info.professional.status.id,
+                        nif: loggedUser.info.personal.nif
+                    });
+                    return;
+                }
+
 
                 // Update the state with the officer's data
                 setCurrentOfficer({

--- a/Frontend/src/pages/Activity/modals/InactivityJustificationModal/index.tsx
+++ b/Frontend/src/pages/Activity/modals/InactivityJustificationModal/index.tsx
@@ -258,6 +258,9 @@ function InactivityJustificationModal({open, onClose, officerNif, justificationI
 
     // Handle websocket events
     useWebSocketEvent<OfficerActivitySocket>(SOCKET_EVENT.ACTIVITY, useCallback((data) => {
+        // If this modal isn't open, it doesn't matter
+        if (!open) return;
+
         // If the event is not about inactivity justifications, it doesn't matter
         if (data.type !== "justification") return;
 
@@ -287,7 +290,7 @@ function InactivityJustificationModal({open, onClose, officerNif, justificationI
             // Show toast with the message
             toast.warning("A justificação que estavas a visualizar foi apagada!");
         }
-    }, [justificationId, loggedUser.info.personal.nif]));
+    }, [open, justificationId, loggedUser.info.personal.nif]));
 
     return (
         <>

--- a/Frontend/src/pages/Dashboard/components/AnnouncementsPanel/AnnouncementModal.tsx
+++ b/Frontend/src/pages/Dashboard/components/AnnouncementsPanel/AnnouncementModal.tsx
@@ -279,7 +279,7 @@ function AnnouncementModal(props: AnnoucencementModalProps) {
                         >
                             <Gate show={!props.newEntry}>
                                 <DefaultTypography color={"var(--portalseguranca-color-accent)"} fontWeight={"bold"}>Author:</DefaultTypography>
-                                <DefaultTypography>{getObjectFromId(announcementData.author.patent, getForceData(announcementData.force).patents)!.name} {announcementData.author.name}</DefaultTypography>
+                                <DefaultTypography>{getObjectFromId(announcementData.author.patent, getForceData(announcementData.author.force ?? localStorage.getItem("force")!).patents)!.name} {announcementData.author.name}</DefaultTypography>
 
                                 <Divider sx={{marginBottom: "5px"}}/>
                             </Gate>

--- a/Frontend/src/pages/OfficerInfo/index.tsx
+++ b/Frontend/src/pages/OfficerInfo/index.tsx
@@ -553,19 +553,6 @@ function OfficerInfo() {
                                     draft.personal.discord = String(event.target.value)
                                 })}
                             />
-                            <Divider flexItem/>
-
-                            {/*Steam pair*/}
-                            {/*Pattern Unit tests: https://regex101.com/r/cZ5DjR/2*/}
-                            <InformationPair
-                                label={"Steam:"}
-                                value={officerInfo.personal.steam}
-                                pattern={/(^steam:([0-9]|[a-z])+$)|(^http(s)?:\/\/steamcommunity\.com\/id\/.+$)/}
-                                editMode={editMode}
-                                onChangeCallback={(event: ChangeEvent<HTMLInputElement>) => setOfficerInfo(draft => {
-                                    draft.personal.steam = event.target.value
-                                })}
-                            />
                         </div>
                     </fieldset>
 

--- a/Frontend/src/pages/OfficerInfo/index.tsx
+++ b/Frontend/src/pages/OfficerInfo/index.tsx
@@ -183,10 +183,11 @@ function OfficerInfo() {
     // Handle updates from socket
     useWebSocketEvent<OfficerSocket>(SOCKET_EVENT.OFFICERS, useCallback((data) => {
         // If the update wasn't for the officer being viewed, return
-        if (data.nif !== officerNif) return;
+        // If nif is 0, then this update came from an import from Google Sheets
+        if (data.nif !== officerNif && data.nif !== 0) return;
 
-        // If the update was triggered by the logged officer, ignore it
-        if (data.by === loggedUser.info.personal.nif) return;
+        // If the update was triggered by the logged officer, ignore it, only if it wasn't an import from Google Sheets
+        if (data.by === loggedUser.info.personal.nif && data.nif !== 0) return;
 
         // If it is an officer being updated, update the info
         if (data.action === "update") {

--- a/Frontend/src/pages/OfficerInfo/modals/RecruitModal.tsx
+++ b/Frontend/src/pages/OfficerInfo/modals/RecruitModal.tsx
@@ -6,7 +6,6 @@ import {toast} from "react-toastify";
 import {ConfirmationDialog, Modal, ModalSection} from "../../../components/Modal";
 import modalsStyle from "./officerinfomodals.module.css";
 import {DefaultButton, DefaultTextField} from "../../../components/DefaultComponents";
-import {Checkbox, FormControlLabel} from "@mui/material";
 import {OfficerInfoGetResponse} from "@portalseguranca/api-types/officers/output";
 import { CreateOfficerRequestBody } from "@portalseguranca/api-types/officers/input.ts";
 import { BaseResponse } from "@portalseguranca/api-types";
@@ -23,8 +22,7 @@ function RecruitModal({open, onClose}: RecruitModalProps): ReactElement {
         phone: "",
         iban: "",
         kms: 0,
-        discord: "",
-        steam: ""
+        discord: ""
     });
 
     // State that hold the confirmation dialog
@@ -49,8 +47,7 @@ function RecruitModal({open, onClose}: RecruitModalProps): ReactElement {
                     phone: Number(officerInfo.phone),
                     iban: officerInfo.iban,
                     kms: officerInfo.kms,
-                    discord: Number(officerInfo.discord),
-                    steam: officerInfo.steam
+                    discord: Number(officerInfo.discord)
                 }
             });
         const recruit_json = await recruitRequest.json() as BaseResponse;
@@ -206,19 +203,6 @@ function RecruitModal({open, onClose}: RecruitModalProps): ReactElement {
                                 required
                                 inputProps={{
                                     name: "officerDiscord"
-                                }}
-                            />
-
-                            <DefaultTextField
-                                fullWidth
-                                label={"Steam ID / URL"}
-                                type={"text"}
-                                onChange={(event) => setOfficerInfo(draft => {draft.steam = event.target.value})}
-                                sx={{margin: "10px 0 0 0"}}
-                                error={officerInfo.steam !== "" && !(/^steam:([0-9]|[a-z])+$/.test(officerInfo.steam)) && !(/^http(s)?:\/\/steamcommunity.com\/id\/.+/.test(officerInfo.steam))}
-                                inputProps={{
-                                    name: "officerSteam",
-                                    pattern: "(^steam:([0-9]|[a-z])+$)|(^http(s)?://steamcommunity.com/id/.+$)"
                                 }}
                             />
                         </div>

--- a/Frontend/src/utils/misc.ts
+++ b/Frontend/src/utils/misc.ts
@@ -16,8 +16,8 @@ export function getTimeDelta(start: Date, end: Date): string {
     return toHoursAndMinutes(Math.floor((end.getTime() - start.getTime()) / 60000));
 }
 
-export async function getOfficerFromNif(nif: number): Promise<OfficerData | MinifiedOfficerData> {
-    const response = await make_request(`/officers/${nif}`, "GET");
+export async function getOfficerFromNif(nif: number, signal?: AbortSignal): Promise<OfficerData | MinifiedOfficerData> {
+    const response = await make_request(`/officers/${nif}`, "GET", {signal});
     const responseJson: RequestError | OfficerInfoGetResponse = await response.json();
 
     if (!response.ok) {


### PR DESCRIPTION
# Enhancements
- É possível agora editar os dados de uma patrulha à qual o utilizador com sessão iniciada seja membro, independentemente de há quanto tempo terminou (#111)
- Removido o campo `steam` da página dos detalhes de Efetivos devido à sua inutilidade
- Na página do histórico de patrulhas, patrulhas que estejam a decorrer mostram agora a sua duração em tempo real (#109)
- Mensagens de erro ao criar patrulhas agora informam o nome do Efetivo problemático em vez do NIF

# Bug Fixes
- APP dá erro quando se abre um anúncio quando se tem uma força ativada que não a de criação (#108)
- Notificações de alterações a detalhes de justificações de inatividade aparecem, mesmo que não tenha nenhuma justificação aberta de momento
- Headers dos requests nos logs não aparecem na totalidade
- Um efetivo com permissão para alterar dados de outras contas consegue editar dados de contas de efetivos com patentes superiores (#110)
- Caso um efetivo que tenha estado numa força anteriormente, mas agora esteja noutra, quando mostra o nome dele, aparece com o nome e patente da força antiga (#112)
- É possível criar uma patrulha que se sobrepõe a outra já existente caso se siga um específco número de passos (#114)
- App atualiza os dados de todos os Efetivos de forma automática após importação do Google Sheets (#116)